### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,17 +4,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SoftwareWire KEYWORD1
+SoftwareWire	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setPins KEYWORD2
+setPins	KEYWORD2
 beginTransmission	KEYWORD2
-write   KEYWORD2
-requestFrom  KEYWORD2
-read KEYWORD2
+write	KEYWORD2
+requestFrom	KEYWORD2
+read	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords