### PR TITLE
Generate compile error when slave mode begin(address) is used

### DIFF
--- a/SoftwareWire.cpp
+++ b/SoftwareWire.cpp
@@ -168,6 +168,7 @@ void SoftwareWire::end()
 }
 
 
+// begin(void) - enter master mode
 // The pins are not changed until begin() is called.
 void SoftwareWire::begin(void)
 {
@@ -185,20 +186,6 @@ void SoftwareWire::begin(void)
   if( _pullups)
     delay(2);           // 1ms didn't always work.
 }
-
-
-void SoftwareWire::begin(uint8_t address)
-{
-  (void)(address);      // fix compiler worning on unused parameter https://github.com/Testato/SoftwareWire/issues/7
-  begin();              // ignore the address parameter, the Slave part is not implemented.
-}
-
-void SoftwareWire::begin(int address)
-{
-  (void)(address);      // fix compiler worning on unused parameter
-  begin();              // ignore the address parameter, the Slave part is not implemented.
-}
-
 
 //
 // beginTransmission starts the I2C transmission immediate.

--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -24,8 +24,11 @@ public:
   void end();
   
   void begin();
-  void begin(uint8_t address);
-  void begin(int address);
+
+  // Generate compile error when slave mode begin(address) is used
+  void __attribute__ ((error("I2C/TWI Slave mode is not supported by the SoftwareWire library"))) begin(uint8_t addr);
+  void __attribute__ ((error("I2C/TWI Slave mode is not supported by the SoftwareWire library"))) begin(int addr);
+
   void setClock(uint32_t clock);
   void beginTransmission(uint8_t address);
   void beginTransmission(int address);


### PR DESCRIPTION
Pull request to generate an error when users attempt use slave mode.
This addresses issue #7 by generating an error vs just making the warnings disappear.

It is pretty minimal. It removes the code for begin(address) and uses and error attribute in the header file.

I've tested this on linux using IDE version 1.8.5 and 1.0.1 
You probably should test it yourself on your machine before it is merged and committed to the master branch.