### PR TITLE
Bug fixed

### DIFF
--- a/SoftwareWire.cpp
+++ b/SoftwareWire.cpp
@@ -790,11 +790,6 @@ void SoftwareWire::i2c_repstart(void)
   
   if (_i2cdelay != 0)
     delayMicroseconds(_i2cdelay);
-
-  i2c_sda_lo();                        // force SDA low
-  
-  if (_i2cdelay != 0)
-    delayMicroseconds(_i2cdelay);
 }
 
 


### PR DESCRIPTION
SDA pin state change during repeated start condition and it wasn't compatible with mpr121.
![softwirebugfix](https://user-images.githubusercontent.com/20865770/45074728-d7e11d80-b0f9-11e8-8509-a3dbb4bb478f.png)

