### PR TITLE
Split endTransmission and requestFrom so function signaturess exactly…

### DIFF
--- a/SoftwareWire.cpp
+++ b/SoftwareWire.cpp
@@ -235,6 +235,9 @@ uint8_t SoftwareWire::endTransmission(boolean sendStop)
   return(_transmission);          // return the transmission status that was set during writing address and data
 }
 
+uint8_t SoftwareWire::endTransmission(void) {
+    return endTransmission(true);
+}
 
 //
 // The requestFrom() read the data from the I2C bus and stores it in a buffer.
@@ -292,6 +295,9 @@ uint8_t SoftwareWire::requestFrom(uint8_t address, uint8_t size, boolean sendSto
   return( n);
 }
 
+uint8_t SoftwareWire::requestFrom(uint8_t address, uint8_t size) {
+    return requestFrom(address, size, true);
+}
 
 //
 uint8_t SoftwareWire::requestFrom(int address, int size, boolean sendStop)

--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -33,8 +33,10 @@ public:
   void setClock(uint32_t clock);
   void beginTransmission(uint8_t address);
   void beginTransmission(int address);
-  uint8_t endTransmission(boolean sendStop = true);
-  uint8_t requestFrom(uint8_t address, uint8_t size, boolean sendStop = true);
+  uint8_t endTransmission(void);
+  uint8_t endTransmission(boolean sendStop);
+  uint8_t requestFrom(uint8_t address, uint8_t size);
+  uint8_t requestFrom(uint8_t address, uint8_t size, boolean sendStop);
   uint8_t requestFrom(int address, int size, boolean sendStop = true);
   size_t write(uint8_t data) override;
   size_t write(const uint8_t *data, size_t quantity) override;


### PR DESCRIPTION
… match TwoWires, so it can be used in 3rd party libraries. (if/when Arduino makes beginTransmission, beginTransmission and requestFrom virtual)