### PR TITLE
Match function prototypes from TwoWire

### DIFF
--- a/SoftwareWire.cpp
+++ b/SoftwareWire.cpp
@@ -235,6 +235,17 @@ uint8_t SoftwareWire::endTransmission(boolean sendStop)
   return(_transmission);          // return the transmission status that was set during writing address and data
 }
 
+//
+uint8_t SoftwareWire::endTransmission(uint8_t sendStop)
+{
+  return endTransmission((boolean) sendStop);
+}
+
+//
+uint8_t SoftwareWire::endTransmission()
+{
+  return endTransmission(true);
+}
 
 //
 // The requestFrom() read the data from the I2C bus and stores it in a buffer.
@@ -292,6 +303,17 @@ uint8_t SoftwareWire::requestFrom(uint8_t address, uint8_t size, boolean sendSto
   return( n);
 }
 
+//
+uint8_t SoftwareWire::requestFrom(uint8_t address, uint8_t size)
+{
+  return requestFrom(address, size, true)
+}
+
+//
+uint8_t SoftwareWire::requestFrom(uint8_t address, uint8_t size, uint8_t sendStop)
+{
+  return requestFrom(address, size, (boolean) sendStop)
+}
 
 //
 uint8_t SoftwareWire::requestFrom(int address, int size, boolean sendStop)
@@ -299,6 +321,17 @@ uint8_t SoftwareWire::requestFrom(int address, int size, boolean sendStop)
   return requestFrom( (uint8_t) address, (uint8_t) size, sendStop);
 }
 
+//
+uint8_t SoftwareWire::requestFrom(int address, int size)
+{
+  return requestFrom(address, size, true)
+}
+
+//
+uint8_t SoftwareWire::requestFrom(int address, int size, uint8_t sendStop)
+{
+  return requestFrom(address, size, (boolean) sendStop)
+}
 
 // must be called in:
 // slave tx event callback

--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -33,9 +33,15 @@ public:
   void setClock(uint32_t clock);
   void beginTransmission(uint8_t address);
   void beginTransmission(int address);
-  uint8_t endTransmission(boolean sendStop = true);
-  uint8_t requestFrom(uint8_t address, uint8_t size, boolean sendStop = true);
-  uint8_t requestFrom(int address, int size, boolean sendStop = true);
+  uint8_t endTransmission(boolean sendStop);
+  uint8_t endTransmission(uint8_t sendStop) override;
+  uint8_t endTransmission() override;
+  uint8_t requestFrom(uint8_t address, uint8_t size, boolean sendStop);
+  uint8_t requestFrom(uint8_t, uint8_t) override;
+  uint8_t requestFrom(uint8_t, uint8_t, uint8_t) override;
+  uint8_t requestFrom(int address, int size, boolean sendStop);
+  uint8_t requestFrom(int, int) override;
+  uint8_t requestFrom(int, int, int) override;
   size_t write(uint8_t data) override;
   size_t write(const uint8_t *data, size_t quantity) override;
   int available(void) override;


### PR DESCRIPTION
This allows the overloads to be called correctly through a TwoWire pointer. In particular, endTransmission and RequestFrom didn't match the TwoWire prototypes, which causes issues when attempting to call through a pointer to a TwoWire object.