### PR TITLE
reduce library size by 2036 bytes of flash (~50%) and 157 bytes of ram (~73%)

### DIFF
--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -3,7 +3,6 @@
 #define SoftwareWire_h
 
 #include <Arduino.h>
-#include <Wire.h>
 
 
 // Transmission status error, the return value of endTransmission()

--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -16,7 +16,7 @@
 #define SOFTWAREWIRE_BUFSIZE 32        // same as buffer size of Arduino Wire library
 
 
-class SoftwareWire : public TwoWire
+class SoftwareWire
 {
 public:
   SoftwareWire();
@@ -36,14 +36,14 @@ public:
   uint8_t endTransmission(boolean sendStop = true);
   uint8_t requestFrom(uint8_t address, uint8_t size, boolean sendStop = true);
   uint8_t requestFrom(int address, int size, boolean sendStop = true);
-  size_t write(uint8_t data) override;
-  size_t write(const uint8_t *data, size_t quantity) override;
-  int available(void) override;
-  int read(void) override;
+  size_t write(uint8_t data);
+  size_t write(const uint8_t *data, size_t quantity);
+  int available(void);
+  int read(void);
   int readBytes(uint8_t* buf, uint8_t size);
   int readBytes(char * buf, uint8_t size);
   int readBytes(char * buf, int size);
-  int peek(void) override;
+  int peek(void);
   void setTimeout(long timeout);  // timeout to wait for the I2C bus
   void printStatus(Print& Ser);   // print information using specified object class
 

--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -21,7 +21,7 @@ class SoftwareWire : public TwoWire
 public:
   SoftwareWire();
   SoftwareWire(uint8_t sdaPin, uint8_t sclPin, boolean pullups = true, boolean detectClockStretch = true);
-  virtual ~SoftwareWire();
+  ~SoftwareWire();
   void end();
 
   void begin();


### PR DESCRIPTION
According to my testing, this library currently consumes about 3926 bytes of flash and 216 bytes of static ram on an Arduino Nano (after subtracting away an empty program that does nothing, i.e. empty `setup()` and empty `loop()`). This PR reduces the flash consumption by 2036 bytes, and ram consumption by 157 bytes, through the following steps:

1)) **Remove virtual on destructor**. Saves 592 bytes of flash and 14 bytes of ram by preventing the virtual destructor from pulling in `malloc()` and `free()`. Making the destructor `virtual` has no benefit for the `SoftwareWire` class as far as I can see, because neither of its parent classes (`TwoWire` and `Stream`) defines a virtual destructor. That means that `SoftwareWire` cannot be deleted polymorphically. In other words, in the following code:

```C++
TwoWire* wire = new SoftwareWire();
delete wire;
```
the `delete` operator calls `~TwoWire()`, not `~SoftwareWire()`. I have actually tested this, and verified that "wrong" destructor (`~TwoWire()`) is called. (It is the correct destructor as far as the C++ language spec is concerned, just not the one that we wanted). When the above code is compiled with warnings enabled, the compiler prints the following warning:

```
warning: deleting object of polymorphic class type 'TwoWire' which has non-virtual 
destructor might cause undefined behavior  [-Wdelete-non-virtual-dtor]
```
which is an additional indication that making the destructor `virtual` does not have the desired effect.

2)) **Remove inheritance from TwoWire**. Saves 304 bytes of flash and 30 bytes of ram. The PR that attempted to make `TwoWire` polymorphic (https://github.com/arduino/ArduinoCore-avr/pull/396) was reverted (https://github.com/arduino/ArduinoCore-avr/pull/412) because it causes `TwoWire` to increase its flash memory by about 650 bytes. I think it is safe to assume that `TwoWire` will *not* support subclassing in the future. So we can save memory by changing `SoftwareWire` to no longer inherit from `TwoWire`.

3)) **Remove including Wire.h**. Saves 1140 bytes of flash and 113 bytes of ram. Just the inclusion of the TwoWire header file (through `#include <Wire.h>`) causes over 1kB of flash to be consumed, even if the`Wire` object is never used. For reasons which are not obvious to me, the compiler is unable to determine that `Wire` is never used in the program, and does not optimize it away during link time. Since (2) above changes `SoftwareWire` so that it is no longer a subclass of `TwoWire`, we no longer need to include `<Wire.h>`.

Total flash savings: 2036 bytes, from 3926 bytes down to 1890 bytes
Total ram savings: 157 bytes, from 216 bytes down to 59 bytes

This PR causes the following effects:

* Obsoletes #29
* Reverts #24
* Reverts #14
* Resolves #28 

For people who are interesting in using this patch, I will probably keep around my fork (https://github.com/bxparks/SoftwareWire) while this PR remains unmerged.