### PR TITLE
Add STM32 boards support through stm32duino

### DIFF
--- a/SoftwareWire.h
+++ b/SoftwareWire.h
@@ -52,15 +52,33 @@ private:
 
   uint8_t _sdaPin;
   uint8_t _sclPin;
+#if defined(ARDUINO_ARCH_STM32)
+  uint32_t _sdaBitMask;
+  uint32_t _sdaModeShift;
+  uint32_t _sclBitMask;
+  uint32_t _sclModeShift;
+#else
   uint8_t _sdaBitMask;
   uint8_t _sclBitMask;
+#endif
 
+
+
+#if defined(ARDUINO_ARCH_STM32)
+  volatile uint32_t *_sdaPortReg;
+  volatile uint32_t *_sclPortReg;
+  volatile uint32_t *_sdaDirReg;
+  volatile uint32_t *_sclDirReg;
+  volatile uint32_t *_sdaPinReg;
+  volatile uint32_t *_sclPinReg;
+#else
   volatile uint8_t *_sdaPortReg;
   volatile uint8_t *_sclPortReg;
   volatile uint8_t *_sdaDirReg;
   volatile uint8_t *_sclDirReg;
   volatile uint8_t *_sdaPinReg;
   volatile uint8_t *_sclPinReg;
+#endif
 
   uint8_t _transmission;      // transmission status, returned by endTransmission(). 0 is no error.
   uint16_t _i2cdelay;         // delay in micro seconds for sda and scl bits.


### PR DESCRIPTION
Add STM32 boards support through stm32duino
https://github.com/stm32duino/Arduino_Core_STM32

Tested on
* Nucleo-L476RG
* Nucleo-F401RE
* Nucleo-G071RB
* Nucleo-F103RB

With LM75 tempetature sensor
with LM75 library modified to use SoftwareWire
https://github.com/thefekete/LM75

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>